### PR TITLE
Add Drift prompt from X post

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ There are several ways you can contribute to this project:
 To add a new video prompt, please follow these steps:
 
 1.  **Create a JSONC file**: Create a new file with the `.jsonc` extension (e.g., `my-awesome-prompt.jsonc`).
-2.  **File Location**: Place your new file in the directory corresponding to the Veo version the prompt is for. For example, prompts for Veo version 1 should go into the `veo-v1/` directory.
+2.  **File Location**: Place your new file in the directory corresponding to the Veo version the prompt is for. For example, prompts for Veo version 1 should go into the `veo/` directory.
 3.  **Content Format**: The JSONC file should contain the following fields:
     ```jsonc
     {

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Video metadata is stored in JSONC files organized by Veo version.
 Example:
 
 ```
-veo-v1/futuristic-cityscape.jsonc
+veo/futuristic-cityscape.jsonc
 ```
 
 Each JSONC file contains fields such as:

--- a/veo/drift.jsonc
+++ b/veo/drift.jsonc
@@ -1,0 +1,11 @@
+{
+  "title": "Drift",
+  "description": "VEO 3 has just launched on Leonardo! The realism is extraordinary. Not just technically impressive, but cinematic in a way that feels lived-in and quietly human.",
+  "prompt": "Drift",
+  "version": "Veo 3",
+  "uploadDate": "2025-06-06",
+  "author": "X user",
+  "videoUrl": "https://x.com/i/status/1930914765947208184",
+  "imageUrl": "https://pbs.twimg.com/amplify_video_thumb/1930914591405449216/img/O8R2QDieSm-suhiV.jpg"
+  // This information was extracted from the referenced X post
+}


### PR DESCRIPTION
## Summary
- add drift.jsonc with text and image URL from the referenced X post
- update docs to use the `veo/` folder name

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842bc25b108832bb1f69b2b2f332c65